### PR TITLE
Fix cache handling bug in Qwen3NextModel

### DIFF
--- a/mlx_lm/models/qwen3_next.py
+++ b/mlx_lm/models/qwen3_next.py
@@ -419,7 +419,8 @@ class Qwen3NextModel(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        mask = create_attention_mask(hidden_states, cache[self.fa_idx])
+        fa_cache = cache[self.fa_idx] if cache is not None else None
+        mask = create_attention_mask(hidden_states, [fa_cache])
 
         for layer, c in zip(self.layers, cache):
             hidden_states = layer(hidden_states, mask=mask, cache=c)


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the Qwen3NextModel where the  function is called with incorrect parameters, causing a runtime error during text generation.

## Problem
The original code was passing  (a single KVCache object) to , but this function expects a list where  is the cache object. This caused the error:


## Solution
The fix wraps the cache object in a list before passing it to :


## Testing
- ✅ Model loads successfully 
- ✅ Text generation works without errors
- ✅ Performance: ~64 tokens/sec generation speed
- ✅ Tested with quantized Qwen3-Next-80B model

## Impact
This enables proper functioning of the Qwen3-Next model with MLX-LM, which was previously broken due to this cache handling bug.